### PR TITLE
fix: truncate long email addresses in user dropdown

### DIFF
--- a/src/components/layout/Header/styles.css
+++ b/src/components/layout/Header/styles.css
@@ -389,6 +389,7 @@
 .dropdown-header {
     padding: 16px 20px;
     border-bottom: 1px solid var(--c-border);
+    overflow: hidden;
 }
 
 .dropdown-name {
@@ -396,11 +397,19 @@
     font-size: 1.1rem;
     color: var(--c-accent-lt);
     margin-bottom: 2px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: block;
 }
 
 .dropdown-email {
     font-size: 0.85rem;
     color: var(--c-muted);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: block;
 }
 
 .dropdown-menu {


### PR DESCRIPTION
Before:
<img width="376" height="509" alt="image" src="https://github.com/user-attachments/assets/bb1b0d4f-3713-44d0-b346-87d525192f2c" />

After:
<img width="384" height="497" alt="image" src="https://github.com/user-attachments/assets/ea82f05d-d488-436d-a218-44a2805814cc" />
