### PR TITLE
fix: incorrect css class name causing search results grid to break on…

### DIFF
--- a/src/pages/Search/index.jsx
+++ b/src/pages/Search/index.jsx
@@ -122,7 +122,7 @@ const Search = () => {
 
     // Helper to render grid
     const renderGrid = (items, isGemini = false) => (
-        <div className="search-grid">
+        <div className="search-results-grid">
             {items.map((item, index) => (
                 <div className={`search-card-wrap ${isGemini ? 'gemini-card-wrap' : ''}`} key={`search-${isGemini ? 'gemini' : 'tmdb'}-${item.id}-${index}`}>
                     <MovieCard

--- a/src/pages/Search/styles.css
+++ b/src/pages/Search/styles.css
@@ -201,7 +201,7 @@
         gap: 1rem;
     }
 
-    .search-grid {
+    .search-results-grid {
         grid-template-columns: repeat(auto-fill, minmax(min(100%, 130px), 1fr));
         gap: 0.5rem;
         justify-content: center;


### PR DESCRIPTION
## Before: 

<img width="1918" height="1032" alt="image" src="https://github.com/user-attachments/assets/c098ec24-c8fa-4a8c-b345-b53ead625b71" />
<img width="1910" height="955" alt="image" src="https://github.com/user-attachments/assets/8a6852c6-9f9c-4e38-be96-7f8e07135088" />
<img width="1883" height="976" alt="image" src="https://github.com/user-attachments/assets/d51060f5-63cb-45d5-9a5b-c70dedc542eb" />

## After:
<img width="818" height="931" alt="image" src="https://github.com/user-attachments/assets/698c228d-4e48-4fb9-9047-71129c4460ed" />
<img width="1293" height="908" alt="image" src="https://github.com/user-attachments/assets/78b2f0b8-7ef3-4612-aeac-0fd1c631850a" />
<img width="1238" height="917" alt="image" src="https://github.com/user-attachments/assets/69af75aa-0c1d-4acf-a546-8ce2975a4bc1" />
<img width="1910" height="977" alt="image" src="https://github.com/user-attachments/assets/7a7395ab-39f0-4c7d-af25-20df338b21f9" />
