### PR TITLE
feat: add per-user search history with Firebase Firestore persistence

### DIFF
--- a/src/api/geminiClient.js
+++ b/src/api/geminiClient.js
@@ -1,5 +1,5 @@
 import { GoogleGenerativeAI } from "@google/generative-ai";
-import { collection, query as firestoreQuery, where, getDocs, addDoc } from "firebase/firestore";
+import { collection, query as firestoreQuery, where, getDocs, addDoc, deleteDoc, doc, orderBy } from "firebase/firestore";
 import { db } from "../firebase";
 import { stopWords } from "../utils/stopWords";
 
@@ -136,5 +136,78 @@ export const fetchGeminiRecommendations = async (query) => {
     } catch (error) {
         console.error("Gemini API Error:", error);
         return []; // Return an empty array on failure so it doesn't break the app
+    }
+};
+
+// ==========================================
+// USER SEARCH HISTORY API
+// ==========================================
+
+export const saveUserSearchHistory = async (userId, query) => {
+    if (!userId || !query || !query.trim()) return;
+
+    try {
+        const historyRef = collection(db, "users", userId, "search_history");
+
+        // Check if this exact query already exists to avoid duplicates
+        const q = firestoreQuery(historyRef, where("query", "==", query.trim().toLowerCase()));
+        const snapshot = await getDocs(q);
+
+        if (!snapshot.empty) {
+            // Already exists, we could optionally update the timestamp here to bump it to the top
+            const docId = snapshot.docs[0].id;
+            // For now, we'll just delete the old one and let it recreate below so it has the freshest timestamp
+            // or simply return out. Deleting and recreating is easiest to bump to top.
+            await deleteDoc(doc(db, "users", userId, "search_history", docId));
+        }
+
+        // Add the new search entry
+        await addDoc(historyRef, {
+            query: query.trim().toLowerCase(),
+            timestamp: new Date()
+        });
+
+        // --- ENFORCE MAX HISTORY LIMIT (Keep only last 10) ---
+        const limitQuery = firestoreQuery(historyRef, orderBy("timestamp", "desc"));
+        const limitSnapshot = await getDocs(limitQuery);
+
+        if (limitSnapshot.size > 10) {
+            // Delete all documents beyond the first 10
+            const docsToDelete = limitSnapshot.docs.slice(10);
+            for (const docSnap of docsToDelete) {
+                await deleteDoc(doc(db, "users", userId, "search_history", docSnap.id));
+            }
+        }
+
+    } catch (error) {
+        console.error("Error saving user search history:", error);
+    }
+};
+
+export const getUserSearchHistory = async (userId) => {
+    if (!userId) return [];
+
+    try {
+        const historyRef = collection(db, "users", userId, "search_history");
+        const q = firestoreQuery(historyRef, orderBy("timestamp", "desc"));
+        const snapshot = await getDocs(q);
+
+        return snapshot.docs.map(doc => ({
+            id: doc.id,
+            ...doc.data()
+        }));
+    } catch (error) {
+        console.error("Error fetching user search history:", error);
+        return [];
+    }
+};
+
+export const removeUserSearchHistory = async (userId, docId) => {
+    if (!userId || !docId) return;
+
+    try {
+        await deleteDoc(doc(db, "users", userId, "search_history", docId));
+    } catch (error) {
+        console.error("Error removing user search history:", error);
     }
 };

--- a/src/components/layout/Header/index.jsx
+++ b/src/components/layout/Header/index.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useAuth } from '@/context/AuthContext';
 import { fetchTMDB } from '@/api/tmdbClient';
+import { getUserSearchHistory, saveUserSearchHistory, removeUserSearchHistory } from '@/api/geminiClient';
 import { TMDB_IMAGE_BASE } from '@/config/constants';
 import './styles.css';
 
@@ -14,14 +15,26 @@ const Header = () => {
     const [search, setSearch] = useState('');
     const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
-    // Search dropdown state
+    // Search dropdown & History state
     const [suggestions, setSuggestions] = useState([]);
+    const [searchHistory, setSearchHistory] = useState([]);
     const [dropdownOpen, setDropdownOpen] = useState(false);
     const [searching, setSearching] = useState(false);
     const debounceTimer = useRef(null);
     const wrapperRef = useRef(null);
 
     const isOnboardingPage = location.pathname === '/onboarding';
+
+    /* ── Load Search History on Mount ── */
+    useEffect(() => {
+        if (currentUser) {
+            getUserSearchHistory(currentUser.uid).then(history => {
+                setSearchHistory(history);
+            });
+        } else {
+            setSearchHistory([]);
+        }
+    }, [currentUser]);
 
     /* ── Live search (debounced) ── */
     useEffect(() => {
@@ -74,10 +87,36 @@ const Header = () => {
     const handleSearch = (e) => {
         e.preventDefault();
         if (search.trim()) {
+            // Save to Firebase history asynchronously (fire and forget)
+            if (currentUser) {
+                saveUserSearchHistory(currentUser.uid, search.trim());
+                // Optimistically update local state so they see it right away next time
+                setSearchHistory(prev => {
+                    const filtered = prev.filter(item => item.query !== search.trim().toLowerCase());
+                    return [{ id: 'temp-' + Date.now(), query: search.trim().toLowerCase() }, ...filtered].slice(0, 10);
+                });
+            }
+
             navigate(`/search?q=${encodeURIComponent(search.trim())}`);
             setDropdownOpen(false);
             setIsMobileMenuOpen(false);
         }
+    };
+
+    const handleHistoryClick = (queryText) => {
+        setSearch(queryText);
+        if (currentUser) saveUserSearchHistory(currentUser.uid, queryText); // bump timestamp
+        navigate(`/search?q=${encodeURIComponent(queryText)}`);
+        setDropdownOpen(false);
+        setIsMobileMenuOpen(false);
+    };
+
+    const handleRemoveHistory = async (e, docId) => {
+        e.stopPropagation();
+        if (currentUser && docId && !docId.startsWith('temp-')) {
+            await removeUserSearchHistory(currentUser.uid, docId);
+        }
+        setSearchHistory(prev => prev.filter(item => item.id !== docId));
     };
 
     const goToItem = (item) => {
@@ -266,7 +305,10 @@ const Header = () => {
                                             placeholder="Search titles…"
                                             value={search}
                                             onChange={e => setSearch(e.target.value)}
-                                            onFocus={() => search.trim() && suggestions.length > 0 && setDropdownOpen(true)}
+                                            onFocus={() => {
+                                                if (search.trim() && suggestions.length > 0) setDropdownOpen(true);
+                                                if (!search.trim() && searchHistory.length > 0) setDropdownOpen(true);
+                                            }}
                                             aria-label="Search movies"
                                             autoComplete="off"
                                         />
@@ -288,54 +330,93 @@ const Header = () => {
                                     {/* ── Dropdown ── */}
                                     {dropdownOpen && (
                                         <div className="search-dropdown">
-                                            {suggestions.length === 0 && !searching ? (
-                                                <div className="search-dropdown__empty">No results found</div>
-                                            ) : (
-                                                <>
+                                            {/* Show Recent Searches if input is empty */}
+                                            {!search.trim() && searchHistory.length > 0 ? (
+                                                <div className="search-dropdown__history">
+                                                    <div className="search-dropdown__history-header">
+                                                        <span>Recent Searches</span>
+                                                    </div>
                                                     <ul className="search-dropdown__list">
-                                                        {suggestions.map(item => (
-                                                            <li key={item.id}>
+                                                        {searchHistory.map(item => (
+                                                            <li key={item.id} className="search-history-item-wrap">
                                                                 <button
-                                                                    className="search-dropdown__item"
-                                                                    onClick={() => goToItem(item)}
+                                                                    className="search-dropdown__item search-dropdown__history-item"
+                                                                    onClick={() => handleHistoryClick(item.query)}
                                                                     type="button"
                                                                 >
-                                                                    {item.poster_path ? (
-                                                                        <img
-                                                                            src={`${TMDB_IMAGE_BASE}${item.poster_path}`}
-                                                                            alt={item.title || item.name}
-                                                                            className="search-dropdown__poster"
-                                                                        />
-                                                                    ) : (
-                                                                        <div className="search-dropdown__poster search-dropdown__poster--placeholder">
-                                                                            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
-                                                                                <rect x="2" y="3" width="20" height="14" rx="2" />
-                                                                                <polyline points="8 21 12 17 16 21" />
-                                                                                <line x1="12" y1="17" x2="12" y2="21" />
-                                                                            </svg>
-                                                                        </div>
-                                                                    )}
-                                                                    <div className="search-dropdown__info">
-                                                                        <span className="search-dropdown__title">{item.title || item.name}</span>
-                                                                        <span className="search-dropdown__meta">
-                                                                            {getYear(item) && <span>{getYear(item)}</span>}
-                                                                            <span className="search-dropdown__type">{getTypeLabel(item)}</span>
-                                                                        </span>
-                                                                    </div>
+                                                                    <svg className="history-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                                                                        <circle cx="12" cy="12" r="10" />
+                                                                        <polyline points="12 6 12 12 16 14" />
+                                                                    </svg>
+                                                                    <span className="search-dropdown__title">{item.query}</span>
+                                                                </button>
+                                                                <button
+                                                                    className="history-remove-btn"
+                                                                    onClick={(e) => handleRemoveHistory(e, item.id)}
+                                                                    title="Remove from history"
+                                                                >
+                                                                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                                                                        <line x1="18" y1="6" x2="6" y2="18" />
+                                                                        <line x1="6" y1="6" x2="18" y2="18" />
+                                                                    </svg>
                                                                 </button>
                                                             </li>
                                                         ))}
                                                     </ul>
-                                                    <button
-                                                        className="search-dropdown__view-all"
-                                                        onClick={viewAllResults}
-                                                        type="button"
-                                                    >
-                                                        View All Results
-                                                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-                                                            <polyline points="9 18 15 12 9 6" />
-                                                        </svg>
-                                                    </button>
+                                                </div>
+                                            ) : (
+                                                /* Show TMDB Live Suggestions if they typed something */
+                                                <>
+                                                    {suggestions.length === 0 && !searching ? (
+                                                        <div className="search-dropdown__empty">No results found</div>
+                                                    ) : (
+                                                        <>
+                                                            <ul className="search-dropdown__list">
+                                                                {suggestions.map(item => (
+                                                                    <li key={item.id}>
+                                                                        <button
+                                                                            className="search-dropdown__item"
+                                                                            onClick={() => goToItem(item)}
+                                                                            type="button"
+                                                                        >
+                                                                            {item.poster_path ? (
+                                                                                <img
+                                                                                    src={`${TMDB_IMAGE_BASE}${item.poster_path}`}
+                                                                                    alt={item.title || item.name}
+                                                                                    className="search-dropdown__poster"
+                                                                                />
+                                                                            ) : (
+                                                                                <div className="search-dropdown__poster search-dropdown__poster--placeholder">
+                                                                                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+                                                                                        <rect x="2" y="3" width="20" height="14" rx="2" />
+                                                                                        <polyline points="8 21 12 17 16 21" />
+                                                                                        <line x1="12" y1="17" x2="12" y2="21" />
+                                                                                    </svg>
+                                                                                </div>
+                                                                            )}
+                                                                            <div className="search-dropdown__info">
+                                                                                <span className="search-dropdown__title">{item.title || item.name}</span>
+                                                                                <span className="search-dropdown__meta">
+                                                                                    {getYear(item) && <span>{getYear(item)}</span>}
+                                                                                    <span className="search-dropdown__type">{getTypeLabel(item)}</span>
+                                                                                </span>
+                                                                            </div>
+                                                                        </button>
+                                                                    </li>
+                                                                ))}
+                                                            </ul>
+                                                            <button
+                                                                className="search-dropdown__view-all"
+                                                                onClick={viewAllResults}
+                                                                type="button"
+                                                            >
+                                                                View All Results
+                                                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                                                                    <polyline points="9 18 15 12 9 6" />
+                                                                </svg>
+                                                            </button>
+                                                        </>
+                                                    )}
                                                 </>
                                             )}
                                         </div>

--- a/src/components/layout/Header/styles/search.css
+++ b/src/components/layout/Header/styles/search.css
@@ -215,3 +215,77 @@
 .topbar__search input::placeholder {
     color: var(--c-muted);
 }
+
+/* ── Search History Styling ── */
+.search-dropdown__history {
+    display: flex;
+    flex-direction: column;
+}
+
+.search-dropdown__history-header {
+    padding: 12px 14px 6px;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-weight: 700;
+    color: var(--c-muted);
+}
+
+.search-history-item-wrap {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 4px;
+    border-radius: 8px;
+    margin: 0 4px;
+    transition: background 0.15s;
+}
+
+.search-history-item-wrap:hover {
+    background: var(--c-surface2);
+}
+
+.search-dropdown__history-item {
+    gap: 14px;
+    padding: 10px;
+    background: transparent;
+    border-radius: 8px;
+    flex: 1;
+}
+
+.search-dropdown__history-item:hover {
+    background: transparent;
+}
+
+.search-dropdown__history-item .history-icon {
+    color: var(--c-muted);
+    flex-shrink: 0;
+}
+
+.search-dropdown__history-item .search-dropdown__title {
+    font-weight: 500;
+    color: var(--c-text2);
+}
+
+.history-remove-btn {
+    background: none;
+    border: none;
+    color: var(--c-muted);
+    padding: 8px;
+    cursor: pointer;
+    border-radius: 6px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.2s;
+    opacity: 0.5;
+}
+
+.search-history-item-wrap:hover .history-remove-btn {
+    opacity: 1;
+}
+
+.history-remove-btn:hover {
+    background: var(--c-border);
+    color: var(--c-error, #ef4444);
+}


### PR DESCRIPTION
<img width="605" height="338" alt="image" src="https://github.com/user-attachments/assets/64742a24-5ff3-4269-a5aa-c5f381807fa1" />

## 📝 Description

Adds a **per-user search history** feature that persists across sessions using Firebase Firestore. When a logged-in user focuses the search bar with an empty input, a dropdown displays their most recent searches with clock icons, allowing them to quickly re-run previous queries or remove individual entries.

## ✨ Features

- **Firestore Persistence** — Each user's search history is stored in a `users/{userId}/search_history` Firestore sub-collection, ensuring history survives page refreshes and cross-device sessions.
- **Automatic Deduplication** — Searching the same term again bumps it to the top instead of creating a duplicate entry.
- **Auto-Limit (10 max)** — Only the 10 most recent searches are kept per user. Older entries are automatically purged.
- **Optimistic UI Updates** — The local history state updates instantly on search; the Firestore write happens asynchronously in the background.
- **Per-Item Removal** — Each history entry has an ✕ button (visible on hover) to remove it from both the UI and Firestore.

## 📁 Files Changed

| File | Change |
|------|--------|
| [src/api/geminiClient.js](cci:7://file:///c:/VS_CODE_FILE/VibeReel/VibeReel/src/api/geminiClient.js:0:0-0:0) | Added [saveUserSearchHistory](cci:1://file:///c:/VS_CODE_FILE/VibeReel/VibeReel/src/api/geminiClient.js:145:0-184:2), [getUserSearchHistory](cci:1://file:///c:/VS_CODE_FILE/VibeReel/VibeReel/src/api/geminiClient.js:186:0-202:2), [removeUserSearchHistory](cci:1://file:///c:/VS_CODE_FILE/VibeReel/VibeReel/src/api/geminiClient.js:204:0-212:2) API functions |
| [src/components/layout/Header/index.jsx](cci:7://file:///c:/VS_CODE_FILE/VibeReel/VibeReel/src/components/layout/Header/index.jsx:0:0-0:0) | Integrated history loading on mount, history dropdown rendering, and save-on-search logic |
| [src/components/layout/Header/styles/search.css](cci:7://file:///c:/VS_CODE_FILE/VibeReel/VibeReel/src/components/layout/Header/styles/search.css:0:0-0:0) | Added CSS for history header, history items, clock icon, and remove button hover states |

## 🔒 Firestore Rules Requirement

Ensure your Firestore security rules allow authenticated users to manage their own history:
## 🔒 Firestore Rules Requirement
Ensure your Firestore security rules allow authenticated users to manage their own history:
match /users/{userId}/search_history/{docId} { allow read, write: if request.auth != null && request.auth.uid == userId; }

## 🧪 How to Test

1. Log in as an authenticated user.
2. Search for 2–3 different terms using the header search bar.
3. Clear the search input and click on the search bar again — the **"Recent Searches"** dropdown should appear with your past queries.
4. Click a history item to re-run that search.
5. Hover over a history item and click the ✕ to remove it.
6. Refresh the page — your history should persist from Firestore.

