### PR TITLE
fix: remove rainbow gradient hover glow from Gemini AI suggestion cards

### DIFF
--- a/src/pages/Search/styles.css
+++ b/src/pages/Search/styles.css
@@ -75,22 +75,7 @@
     text-shadow: 0 0 20px rgba(162, 89, 255, 0.4);
 }
 
-/* Slight glow effect to differentiate AI suggestions */
-
-.gemini-card-wrap::after {
-    content: '';
-    position: absolute;
-    inset: -2px;
-    background: linear-gradient(135deg, rgba(162, 89, 255, 0.4) 0%, rgba(255, 98, 165, 0.4) 50%, rgba(255, 184, 77, 0.4) 100%);
-    border-radius: 14px;
-    z-index: -1;
-    opacity: 0;
-    transition: opacity 0.3s ease;
-}
-
-.gemini-card-wrap:hover::after {
-    opacity: 1;
-}
+/* Gemini card hover glow removed per user request */
 
 .gemini-indicator {
     position: absolute;


### PR DESCRIPTION
## Before:
<img width="1893" height="914" alt="image" src="https://github.com/user-attachments/assets/833236d1-af4c-4ffe-8e08-ee67a593d348" />
<img width="1835" height="810" alt="image" src="https://github.com/user-attachments/assets/662e8304-78b2-4f2f-b22c-5fe59122dbde" />

## After:
<img width="1835" height="897" alt="image" src="https://github.com/user-attachments/assets/20713f37-5fa0-4712-a8b2-f6920f3e3fb4" />
<img width="392" height="389" alt="image" src="https://github.com/user-attachments/assets/1cf7c25e-2c72-406f-ae2e-e1b67fc95955" />

---
## Remove the gradient hover glow from Gemini AI suggestion cards